### PR TITLE
#79 - Installation Not Possible Due To Missing Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ logs/
 /titanbot/static/
 __pycache__
 titan.sqlite3
-package.json
 node_modules/
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "tt2_py",
+  "version": "1.0.0",
+  "description": "TitanDash",
+  "main": "index.js",
+  "scripts": {
+    "build": "webpack --config webpack.config.js --progress --colors --mode development",
+    "watch": "webpack --config webpack.config.js --watch --mode development"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/becurrie/tt2_py.git"
+  },
+  "author": "becurrie",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/becurrie/tt2_py/issues"
+  },
+  "homepage": "https://github.com/becurrie/tt2_py#readme",
+  "dependencies": {
+    "bootstrap": "^4.3.1",
+    "datatables.net-bs4": "^1.10.19",
+    "datatables.net-responsive-bs4": "^2.2.3",
+    "moment": "^2.24.0",
+    "jquery": "^3.4.1"
+  },
+  "devDependencies": {
+    "@fortawesome/fontawesome-free": "^5.9.0"
+  }
+}


### PR DESCRIPTION
Gitignore updated to allow for the package.json file to be included. This is needed when installing dependencies.