### PR TITLE
#480 Fix No Artifact Upgrade Selected On Prestige

### DIFF
--- a/titanbot/titandash/bot/core/bot.py
+++ b/titanbot/titandash/bot/core/bot.py
@@ -1603,6 +1603,11 @@ class Bot(object):
                 return False
 
             artifact = self.next_artifact_upgrade
+            
+            if artifact is None:
+                self.logger.info("no artifact to upgrade, skipping purchase.")
+                return
+            
             # Access to current upgrade is present above,
             # go ahead and update the next artifact to purchase.
             self.update_next_artifact_upgrade()

--- a/titanbot/titandash/bot/core/bot.py
+++ b/titanbot/titandash/bot/core/bot.py
@@ -1603,11 +1603,6 @@ class Bot(object):
                 return False
 
             artifact = self.next_artifact_upgrade
-            
-            if artifact is None:
-                self.logger.info("no artifact to upgrade, skipping purchase.")
-                return
-            
             # Access to current upgrade is present above,
             # go ahead and update the next artifact to purchase.
             self.update_next_artifact_upgrade()


### PR DESCRIPTION
When no artifact is selected in the [GUI](https://i.imgur.com/IMQL4IM.png), but it's checked to upgrade Artifacts an exception is thrown.

`cv2.error: OpenCV(4.1.1) C:\projects\opencv-python\opencv\modules\imgproc\src\color.cpp:182: error: (-215:Assertion failed) !_src.empty() in function 'cv::cvtColor'`

This is caused by `cv2.imread()` which doesn't throw an excepion on failure.

