### PR TITLE
#481 Improve OCR Quality/Accuracy

### DIFF
--- a/titanbot/titandash/bot/core/bot.py
+++ b/titanbot/titandash/bot/core/bot.py
@@ -1603,6 +1603,11 @@ class Bot(object):
                 return False
 
             artifact = self.next_artifact_upgrade
+            
+            if artifact is None:
+                self.logger.info("no artifact to upgrade, skipping purchase.")
+                return
+            
             # Access to current upgrade is present above,
             # go ahead and update the next artifact to purchase.
             self.update_next_artifact_upgrade()

--- a/titanbot/titandash/bot/core/bot.py
+++ b/titanbot/titandash/bot/core/bot.py
@@ -1603,11 +1603,6 @@ class Bot(object):
                 return False
 
             artifact = self.next_artifact_upgrade
-            
-            if artifact is None:
-                self.logger.info("no artifact to upgrade, skipping purchase.")
-                return
-            
             # Access to current upgrade is present above,
             # go ahead and update the next artifact to purchase.
             self.update_next_artifact_upgrade()

--- a/titanbot/titandash/bot/core/maps.py
+++ b/titanbot/titandash/bot/core/maps.py
@@ -423,7 +423,7 @@ STAGE_COORDS = {
 PRESTIGE_COORDS = {
     "base": {
         "time_since": (301, 155, 380, 177),
-        "advance_start": (136, 584, 212, 612),
+        "advance_start": (137, 600, 195, 620),
     },
     "event": {
         "time_since": (301, 121, 380, 139),

--- a/titanbot/titandash/bot/core/stats.py
+++ b/titanbot/titandash/bot/core/stats.py
@@ -111,7 +111,7 @@ class Stats:
         kernel = np.ones((1, 1), np.uint8)
         image = cv2.dilate(image, kernel, iterations=iterations)
         image = cv2.erode(image, kernel, iterations=iterations)
-
+        
         return Image.fromarray(image)
 
     def _process_stage(self, scale=5, threshold=100, image=None):
@@ -127,7 +127,7 @@ class Stats:
         # Create gray scale.
         image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         # Perform threshold on image.
-        retr, mask = cv2.threshold(image, 230, 255, cv2.THRESH_BINARY)
+        retr, mask = cv2.threshold(image, 230, 255, cv2.THRESH_BINARY_INV)
 
         # Find contours.
         contours, hier = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
@@ -352,8 +352,9 @@ class Stats:
         else:
             self.grabber.snapshot(region=region)
             image = self._process_stage(scale=3)
-
-        text = pytesseract.image_to_string(image, config='--psm 7 nobatch digits')
+        
+        text = pytesseract.image_to_string(image, config="--psm 7 nobatch digits --oem 0")
+               
         self.logger.debug("parsed value: {text}".format(text=text))
 
         # Do some light parse work here to make sure only digit like characters are present
@@ -374,9 +375,9 @@ class Stats:
             image = self._process_stage(test_image)
         else:
             self.grabber.snapshot(region=region)
-            image = self._process_stage()
+            image = self._process(region=region)
 
-        text = pytesseract.image_to_string(image, config="--psm 7 nobatch digits")
+        text = pytesseract.image_to_string(image, config="--psm 7 nobatch digits --oem 0")
         self.logger.info("parsed value: {text}".format(text=text))
 
         # Doing some light parse work, similar to the stage ocr function to remove letters if present.
@@ -399,7 +400,8 @@ class Stats:
         if test_image:
             image = self._process(scale=3, image=test_image)
         else:
-            image = self._process(scale=3, current=True, region=region)
+            self.grabber.snapshot(region=region)
+            image = self._process(scale=3)
 
         text = pytesseract.image_to_string(image, config='--psm 7')
         self.logger.info("parsed value: {text}".format(text=text))

--- a/titanbot/titandash/bot/core/stats.py
+++ b/titanbot/titandash/bot/core/stats.py
@@ -281,7 +281,7 @@ class Stats:
                 image = Image.open(test_set[key])
             else:
                 self.grabber.snapshot(region=region)
-                image = self._process()
+                image = self._process(scale=3)
 
             text = pytesseract.image_to_string(image, config='--psm 7')
             self.logger.debug("ocr result: {key} -> {text}".format(key=key, text=text))
@@ -354,7 +354,6 @@ class Stats:
             image = self._process_stage(scale=3)
         
         text = pytesseract.image_to_string(image, config="--psm 7 nobatch digits --oem 0")
-               
         self.logger.debug("parsed value: {text}".format(text=text))
 
         # Do some light parse work here to make sure only digit like characters are present


### PR DESCRIPTION
Fixing https://github.com/becurrie/titandash/issues/481

Explanation:

+ Use Legacy Mode for OCR and use a decent traineddata file for it.
+ Invert Colors (Tess 4.0+ is better at finding white text on black background) 