### PR TITLE
#523 Fix Level Heroes Skipping Drag/Click Due To Static Headers

### DIFF
--- a/titanbot/titandash/bot/core/bot.py
+++ b/titanbot/titandash/bot/core/bot.py
@@ -821,8 +821,18 @@ class Bot(object):
                 # Begin level and scrolling process. An assumption is made that all heroes
                 # are unlocked, meaning that some un-necessary scrolls may take place.
                 self.logger.info("scrolling and levelling all heroes present.")
-                while not self.grabber.search(image=self.images.masteries, bool_only=True):
-                    self.logger.info("levelling heroes on screen...")
+
+                _loops = 0
+                _last = self.grabber.snapshot(region=PANEL_COORDS["panel_check"])
+                _current = _last
+
+                while True:
+                    if _loops == FUNCTION_LOOP_TIMEOUT:
+                        self.logger.warning("reached limit allowed for hero levelling, finishing now...")
+                        break
+
+                    _loops += 1
+
                     for point in HEROES_LOCS["level_heroes"]:
                         self.click(
                             point=point,
@@ -836,6 +846,12 @@ class Bot(object):
                         end=drag_end,
                         pause=1
                     )
+
+                    _last = _current
+                    _current = self.grabber.snapshot(region=PANEL_COORDS["panel_check"])
+
+                    if self.stats.images_duplicate(image_one=_last, image_two=_current):
+                        break
 
                 # Performing one additional heroes level after the top
                 # has been reached...


### PR DESCRIPTION
… from the bottom upwards.

- Level heroes was using an inline drag until the old "top" image for heroes was found.
- Before 3.9.0, this was the masteries icon, which is now always present due to static headers.
- We now do a duplicate image check when levelling heroes upwards.